### PR TITLE
Improved Java instructions for TLS 1.2

### DIFF
--- a/src/overview.rst
+++ b/src/overview.rst
@@ -81,7 +81,14 @@ time to time.
             TLS 1.2:
             
             * OpenSSL 1.0.1
-            * Java 8u32
+            * Java
+
+                **8** You don't need to do any additional work to support TLS 1.2, it's supported by default 
+                
+                **7** TLS 1.2 is supported by `making configuration changes  <https://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider>`_
+                
+                **6u121+** TLS 1.2 is supported by `making configuration changes <http://www.oracle.com/technetwork/java/javase/overview-156328.html#R160_121>`_
+                
             * `TLS 1.2 and .Net support <https://blogs.perficient.com/microsoft/2016/04/tsl-1-2-and-net-support/>`_.
 
                 **.NET 4.6 and above** You don’t need to do any


### PR DESCRIPTION
While we reference 1.1 later, I want to give a stronger direction to encourage all version of Java towards TLS 1.2.